### PR TITLE
implement dataframe selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ TODO
 - [X] Implementation of `Series` and `DataFrame`
 - [X] CSV file reading
 - [X] Data display methods
-- [ ] Selection by index, label, and condition
+- [X] Selection by index, label, and condition
 - [ ] Basic statistics and advanced operations
 
 ### Deployment & Publishing

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -135,15 +135,16 @@ public class Dataframe {
         return new Dataframe(getLabels(), newData);
     }
 
+
     /**
-     * Returns a new Dataframe containing rows in the range [from, to).
-     * Mimics Pandas' df.iloc[from:to].
-     *
-     * @param from the start index (inclusive)
-     * @param to the end index (exclusive)
-     * @return a new Dataframe with selected rows
-     * @throws IllegalArgumentException if the range is invalid
-     */
+    * Returns a new Dataframe containing only the specified rows (by range).
+    * Mimics Pandas' df.iloc[from:to]
+    *
+    * @param from the starting index (included)
+    * @param to the end index (excluded)
+    * @return a new Dataframe with those rows
+    * @throws IllegalArgumentException if the range is invalid
+*/
     public Dataframe selectRowsRange(int from, int to) {
         if (from < 0 || to > data_tab[0].getData().size() || from >= to) {
             throw new IllegalArgumentException("Invalid row range");
@@ -157,6 +158,14 @@ public class Dataframe {
         return selectRows(indices);
     }
 
+    /**
+    * Returns a new Dataframe containing only the specified columns (by labels).
+    * Mimics Pandas' df[["col1", "col2", ...]]
+    *
+    * @param labels the labels of the columns to include
+    * @return a new Dataframe with those columns
+    * @throws IllegalArgumentException if any label is not found
+*/
     public Dataframe selectColumns (String... labels) {
         List<Series<?>> selectedSeries = new ArrayList<>();
         List<String> selectedLabels = new ArrayList<>();

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -5,6 +5,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Represents a dataframe structure containing multiple series of data.
@@ -105,18 +106,54 @@ public class Dataframe {
         return data_tab;
     }
 
+    /**
+     * Returns a new Dataframe containing only the specified rows (by index).
+     * Mimics Pandas' df.iloc[[i1, i2, ...]].
+     *
+     * @param indices the exact row indices to include
+     * @return a new Dataframe with those rows
+     * @throws IllegalArgumentException if any index is out of bounds
+     */
+    public Dataframe selectRows(int... indices) {
+        int rowCount = data_tab[0].getData().size();
+        Object[] newData = new Object[data_tab.length];
+
+        for (int col = 0; col < data_tab.length; col++) {
+            List<?> originalCol = data_tab[col].getData();
+            List<Object> selectedCol = new ArrayList<>();
+
+            for (int idx : indices) {
+                if (idx < 0 || idx >= rowCount) {
+                    throw new IllegalArgumentException("Row index out of bounds: " + idx);
+                }
+                selectedCol.add(originalCol.get(idx));
+            }
+
+            newData[col] = selectedCol.toArray();
+        }
+
+        return new Dataframe(getLabels(), newData);
+    }
+
+    /**
+     * Returns a new Dataframe containing rows in the range [from, to).
+     * Mimics Pandas' df.iloc[from:to].
+     *
+     * @param from the start index (inclusive)
+     * @param to the end index (exclusive)
+     * @return a new Dataframe with selected rows
+     */
     public Dataframe selectRows(int from, int to) {
         if (from < 0 || to > data_tab[0].getData().size() || from >= to) {
             throw new IllegalArgumentException("Invalid row range");
         }
 
-        Object[] newData = new Object[data_tab.length];
-        for (int i = 0; i < data_tab.length; i++) {
-            List<?> columnData = data_tab[i].getData().subList(from, to);
-            newData[i] = columnData.toArray();
+        int[] indices = new int[to - from];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = from + i;
         }
 
-        return new Dataframe(getLabels(), newData);
+        return selectRows(indices);
     }
 
     public Dataframe selectColumn (String... labels) {

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -142,6 +142,7 @@ public class Dataframe {
      * @param from the start index (inclusive)
      * @param to the end index (exclusive)
      * @return a new Dataframe with selected rows
+     * @throws IllegalArgumentException if the range is invalid
      */
     public Dataframe selectRowsRange(int from, int to) {
         if (from < 0 || to > data_tab[0].getData().size() || from >= to) {

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -183,6 +183,53 @@ public class Dataframe {
         return new Dataframe(selectedLabels.toArray(new String[0]), newData);
     }
 
+    /**
+     * Returns a new Dataframe containing only the rows for which the given predicate evaluates to true,
+     * based on the values in a specified column.
+     * <p>
+     * This method provides a flexible way to perform advanced filtering, similar to Pandas' conditional selection
+     * (e.g., {@code df[df["col"] > 10]}). The user is responsible for ensuring that the predicate correctly handles
+     * the type of the column's values.
+     * <p>
+     * Example usage:
+     * <pre>{@code
+     *     Dataframe df = ...;
+     *     Dataframe filtered = df.filterRows("Age", value -> ((Integer) value) > 30);
+     * }</pre>
+     *
+     * @param columnLabel The label of the column to use for filtering.
+     * @param condition   A predicate that takes a column value and returns true if the corresponding row should be kept.
+     * @return A new Dataframe containing only the rows where the condition is true.
+     * @throws IllegalArgumentException if the specified column does not exist.
+     */
+    public Dataframe filterRows(String columnLabel, Predicate<Object> condition) {
+        int colIndex = -1;
+        for (int i = 0; i < data_tab.length; i++) {
+            if (data_tab[i].getName().equals(columnLabel)) {
+                colIndex = i;
+                break;
+            }
+        }
+
+        if (colIndex == -1) {
+            throw new IllegalArgumentException("Column not found: " + columnLabel);
+        }
+
+        List<?> targetColumn = data_tab[colIndex].getData();
+        List<Integer> matchingIndices = new ArrayList<>();
+
+        for (int i = 0; i < targetColumn.size(); i++) {
+            Object value = targetColumn.get(i);
+            if (condition.test(value)) {
+                matchingIndices.add(i);
+            }
+        }
+
+        // convert List<Integer> to int[] for selectRows
+        int[] indices = matchingIndices.stream().mapToInt(Integer::intValue).toArray();
+        return selectRows(indices);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -105,6 +105,47 @@ public class Dataframe {
         return data_tab;
     }
 
+    public Dataframe selectRows(int from, int to) {
+        if (from < 0 || to > data_tab[0].getData().size() || from >= to) {
+            throw new IllegalArgumentException("Invalid row range");
+        }
+
+        Object[] newData = new Object[data_tab.length];
+        for (int i = 0; i < data_tab.length; i++) {
+            List<?> columnData = data_tab[i].getData().subList(from, to);
+            newData[i] = columnData.toArray();
+        }
+
+        return new Dataframe(getLabels(), newData);
+    }
+
+    public Dataframe selectColumn (String... labels) {
+        List<Series<?>> selectedSeries = new ArrayList<>();
+        List<String> selectedLabels = new ArrayList<>();
+
+        for (String label : labels) {
+            boolean found = false;
+            for (Series<?> series : data_tab) {
+                if (series.getName().equals(label)) {
+                    selectedSeries.add(series);
+                    selectedLabels.add(label);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new IllegalArgumentException("Column not found: " + label);
+            }
+        }
+
+        Object[] newData = new Object[selectedSeries.size()];
+        for (int i = 0; i < selectedSeries.size(); i++) {
+            newData[i] = selectedSeries.get(i).getData().toArray();
+        }
+
+        return new Dataframe(selectedLabels.toArray(new String[0]), newData);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
+++ b/src/main/java/com/github/hugorouillard/dataframe/Dataframe.java
@@ -143,7 +143,7 @@ public class Dataframe {
      * @param to the end index (exclusive)
      * @return a new Dataframe with selected rows
      */
-    public Dataframe selectRows(int from, int to) {
+    public Dataframe selectRowsRange(int from, int to) {
         if (from < 0 || to > data_tab[0].getData().size() || from >= to) {
             throw new IllegalArgumentException("Invalid row range");
         }
@@ -156,7 +156,7 @@ public class Dataframe {
         return selectRows(indices);
     }
 
-    public Dataframe selectColumn (String... labels) {
+    public Dataframe selectColumns (String... labels) {
         List<Series<?>> selectedSeries = new ArrayList<>();
         List<String> selectedLabels = new ArrayList<>();
 

--- a/src/test/java/DataFrameSelectionTest.java
+++ b/src/test/java/DataFrameSelectionTest.java
@@ -1,0 +1,87 @@
+import com.github.hugorouillard.dataframe.Dataframe;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+
+public class DataFrameSelectionTest {
+
+    @Test
+    public void testSelectRowsRange() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new int[]{22, 25, 30, 27});
+
+        Dataframe result = df.selectRowsRange(1, 3); // Bob & Charlie
+
+        assertEquals(2, result.getDataTab()[0].getData().size());
+        assertEquals("Bob", result.getDataTab()[0].getData().get(0));
+        assertEquals("Charlie", result.getDataTab()[0].getData().get(1));
+        assertEquals(25, result.getDataTab()[1].getData().get(0));
+        assertEquals(30, result.getDataTab()[1].getData().get(1));
+    }
+
+    @Test
+    public void testSelectRowsIndices() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new int[]{22, 25, 30, 27});
+
+        Dataframe result = df.selectRows(0, 3); // Alice & Dora
+
+        assertEquals(2, result.getDataTab()[0].getData().size());
+        assertEquals("Alice", result.getDataTab()[0].getData().get(0));
+        assertEquals("Dora", result.getDataTab()[0].getData().get(1));
+    }
+
+    @Test
+    public void testSelectColumns() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age", "Score"},
+                new String[]{"Alice", "Bob", "Charlie"},
+                new int[]{22, 25, 30},
+                new double[]{10.5, 9.8, 12.0});
+
+        Dataframe result = df.selectColumns("Name", "Score");
+
+        assertEquals(2, result.getDataTab().length);
+        assertEquals("Name", result.getDataTab()[0].getName());
+        assertEquals("Score", result.getDataTab()[1].getName());
+        assertEquals("Alice", result.getDataTab()[0].getData().get(0));
+        assertEquals(12.0, (Double) result.getDataTab()[1].getData().get(2), 0.001);
+    }
+
+    @Test
+    public void testFilterRowsWithCast() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new Integer[]{22, 25, 30, 27});
+
+        Predicate<Object> olderThan25 = val -> ((Integer) val) > 25;
+
+        Dataframe result = df.filterRows("Age", olderThan25);
+
+        assertEquals(2, result.getDataTab()[0].getData().size());
+        assertEquals("Charlie", result.getDataTab()[0].getData().get(0));
+        assertEquals("Dora", result.getDataTab()[0].getData().get(1));
+        assertEquals(30, result.getDataTab()[1].getData().get(0));
+        assertEquals(27, result.getDataTab()[1].getData().get(1));
+    }
+
+    @Test
+    public void testFilterRowsByNameStartsWith() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Anna", "Dora"},
+                new Integer[]{22, 25, 23, 27});
+
+        Predicate<Object> startsWithA = val -> ((String) val).startsWith("A");
+
+        Dataframe result = df.filterRows("Name", startsWithA);
+
+        assertEquals(2, result.getDataTab()[0].getData().size());
+        assertEquals("Alice", result.getDataTab()[0].getData().get(0));
+        assertEquals("Anna", result.getDataTab()[0].getData().get(1));
+        assertEquals(22, result.getDataTab()[1].getData().get(0));
+        assertEquals(23, result.getDataTab()[1].getData().get(1));
+    }
+}

--- a/src/test/java/DataFrameSelectionTest.java
+++ b/src/test/java/DataFrameSelectionTest.java
@@ -84,4 +84,43 @@ public class DataFrameSelectionTest {
         assertEquals(22, result.getDataTab()[1].getData().get(0));
         assertEquals(23, result.getDataTab()[1].getData().get(1));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSelectRowsRangeInvalidRange() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new int[]{22, 25, 30, 27});
+
+        df.selectRowsRange(3, 1); // Invalid range
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSelectRowsIndicesOutOfBounds() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new int[]{22, 25, 30, 27});
+
+        df.selectRows(0, 5); // Index out of bounds
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSelectColumnsInvalidColumnName() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age", "Score"},
+                new String[]{"Alice", "Bob", "Charlie"},
+                new int[]{22, 25, 30},
+                new double[]{10.5, 9.8, 12.0});
+
+        df.selectColumns("Name", "InvalidColumn"); // Invalid column name
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFilterRowsInvalidColumnName() {
+        Dataframe df = new Dataframe(new String[]{"Name", "Age"},
+                new String[]{"Alice", "Bob", "Charlie", "Dora"},
+                new Integer[]{22, 25, 30, 27});
+
+        Predicate<Object> olderThan25 = val -> ((Integer) val) > 25;
+
+        df.filterRows("InvalidColumn", olderThan25); // Invalid column name
+    }
 }


### PR DESCRIPTION
This pr adds flexible row and column selection methods

- `selectRowRange(int from, int to)` mimics slicing rows as in [`df.iloc[from:to]`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iloc.html)
- `selectRows(int[] indices)` corresponds to [`df.iloc[[i1, i2, ...]]`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iloc.html#pandas.DataFrame.iloc) for selecting arbitrary rows
- `selectColumns(String... labels)` is equivalent to [`df[["col1", "col2"]]`](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#selection-by-label)
- `filterRows(String columnlabel, Predicate<object> condition)` enables filtering by condition, similar to [`df[df["col"] > x]`](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#boolean-indexing)

